### PR TITLE
Show the menu in Mac only

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -134,8 +134,10 @@ const template = [
   }
 ]
 
-const menu = Menu.buildFromTemplate(template)
-Menu.setApplicationMenu(menu)
+if (process.platform === 'darwin') {
+  const menu = Menu.buildFromTemplate(template)
+  Menu.setApplicationMenu(menu)
+}
 
 function createWindow() {
   // Create the browser window.


### PR DESCRIPTION
- [x] Only show the menu in MacOS.
- [ ] Adapt design for missing options