### PR TITLE
Fixed the issue: About window does not show on linux

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -54,12 +54,13 @@ const template = [
     label: app.name,
     submenu: [
       { 
-	role: 'about',
-	async click() {
+	      role: 'about',
+	      async click() {
           if (isLinux) {
             const version = require("../package.json").version;
+            const name = require("../package.json").name;
             dialog.showMessageBox({
-              message: "linked",
+              message: name,
               detail: "Version " + version + " (" + version + ")\nCopyright © 2022 André Weller",
               type: "info",
               title: "About",

--- a/src/background.js
+++ b/src/background.js
@@ -54,8 +54,8 @@ const template = [
     label: app.name,
     submenu: [
       { 
-	      role: 'about',
-	      async click() {
+        role: 'about',
+        async click() {
           if (isLinux) {
             const version = require("../package.json").version;
             const name = require("../package.json").name;

--- a/src/background.js
+++ b/src/background.js
@@ -64,7 +64,7 @@ const template = [
               detail: "Version " + version + " (" + version + ")\nCopyright © 2022 André Weller",
               type: "info",
               title: "About",
-              icon: "../appIcon/icon.png"
+              icon: path.join(__dirname, '..', "appIcon/icon.png")
             });
           }
         }

--- a/src/background.js
+++ b/src/background.js
@@ -16,6 +16,7 @@ import {
 const isDevelopment = process.env.NODE_ENV !== 'production'
 const isWindows = process.platform === 'win32'
 const isMacOS = process.platform === 'darwin'
+const isLinux = process.platform === 'linux'
 
 let win
 
@@ -52,7 +53,21 @@ const template = [
   {
     label: app.name,
     submenu: [
-      { role: 'about' },
+      { 
+	role: 'about',
+	async click() {
+          if (isLinux) {
+            const version = require("../package.json").version;
+            dialog.showMessageBox({
+              message: "linked",
+              detail: "Version " + version + " (" + version + ")\nCopyright © 2022 André Weller",
+              type: "info",
+              title: "About",
+              icon: "../appIcon/icon.png"
+            });
+          }
+        }
+      },
       {
         label: 'Settings',
         accelerator: 'CommandOrControl + ,',


### PR DESCRIPTION
I created a validation to check if the OS is Linux, if yes, it will create a dialog box with the message:
"Version: (version)
Copyright © 2022 André Weller"
Unfortunately, I couldn't add the logo, even adding it to the options of showMessageBox, it just doesn't shows up.
(Resending it, but edited from nano, instead of Vim, I think this way it won't change the line breaks etc)