### PR TITLE
Fixed slash command popup #184

### DIFF
--- a/src/translation.js
+++ b/src/translation.js
@@ -14,7 +14,7 @@ export const translate = async (identifier, locale = localStorage.lang, data = {
 
 export const Translations = {
   locale: localStorage.lang ?? 'de-DE',
-  translationStrings: import(`./locales/${localStorage.lang}.json`),
+  translationStrings: import(`./locales/${this.locale}.json`),
   install(VueInstance) {
     VueInstance.prototype.$setLocale = function (locale) {
       this.locale = locale;

--- a/src/translation.js
+++ b/src/translation.js
@@ -13,8 +13,8 @@ export const translate = async (identifier, locale = localStorage.lang, data = {
 }
 
 export const Translations = {
-  locale: localStorage.lang ?? 'de-DE',
-  translationStrings: import(`./locales/${this.locale}.json`),
+  locale: localStorage.lang ?? 'en-US',
+  translationStrings: import(`./locales/${this.locale || 'en-US'}.json`),
   install(VueInstance) {
     VueInstance.prototype.$setLocale = function (locale) {
       this.locale = locale;


### PR DESCRIPTION
Issue #184 solved.

### Bug description:

When you do a clean installation for devs, slash command popups doesn't show.

### Fix description:


The problem is that variable localstorage.lang hasn't a default value so if you don't pick a language in the dropdown menu of the application settings the slash popups doesn't appears.

> The "locale" variable had the default value, but was never used because the variable "localStorage.lang" was being assigned instead, so we just change "loaclStorage.lang" for "this.locale".

- Before fix:

<img width="1404" alt="Captura de Pantalla 2022-10-09 a las 12 49 11" src="https://user-images.githubusercontent.com/61242676/194753853-72dd9723-8046-443b-85e8-8d0c9cdae42e.png">

- After fix:

<img width="976" alt="Captura de Pantalla 2022-10-09 a las 12 52 00" src="https://user-images.githubusercontent.com/61242676/194753868-29126bb9-410f-4b3b-a5f8-47744aee79fa.png">


