### PR TITLE
:bug: fixes #160 by disabling spellcheck in the editor

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -172,7 +172,8 @@ const createWindow = () => {
       devTools: process.env.NODE_ENV === 'development',
       nodeIntegration: true,
       contextIsolation: false,
-      enableRemoteModule: true
+      enableRemoteModule: true,
+      spellcheck: false
     }
   })
 


### PR DESCRIPTION
This PR closes #160 by adding the `spellcheck` property in `BrowserWindow` and setting it to `false`

Behaviour before the fix:

<img width="466" alt="Screen Shot 2022-10-28 at 6 50 00 PM" src="https://user-images.githubusercontent.com/50856799/198748717-49585806-bc9b-4fbb-a2c1-783b439c800d.png">

Behaviour introduced:
<img width="469" alt="Screen Shot 2022-10-28 at 6 52 26 PM" src="https://user-images.githubusercontent.com/50856799/198749006-a6051c57-2ded-454b-aa07-803ab2d3e005.png">




Thank you, @lostdesign, for your help. 